### PR TITLE
Conflicting update prevention

### DIFF
--- a/header.el
+++ b/header.el
@@ -246,21 +246,21 @@
   )
 
 
-(defun header-update ()
-  "Updates the header for the current source file."
-  (interactive)
-  (save-excursion
-    (if (buffer-modified-p)
-        (progn
-          (goto-char (point-min))
-          (if (search-forward "Updated" nil t)
+      (defun header-update ()
+        "Updates the header for the current source file."
+        (interactive)
+        (save-excursion
+          (if (buffer-modified-p)
               (progn
-                (delete-region
-                 (progn (beginning-of-line) (point))
-                 (progn (end-of-line) (point)))
-				(header-insert-line-09)
-                (message "Header up to date."))))))
-  nil)
+                (goto-char (point-min))
+                (if (search-forward "Updated:" 891 t 1)
+                    (progn
+                      (delete-region
+                       (progn (beginning-of-line) (point))
+                       (progn (end-of-line) (point)))
+                                      (header-insert-line-09)
+                      (message "Header up to date."))))))
+        nil)
 
 
 


### PR DESCRIPTION
In case this is added to a config org file, the search-forward (line 256) function will only look up to where the header would be, preventing it from adding "Creates the 'Updated: yyyy/mm/dd hh:mm:ss' entry of the header.'" to an undesired location. 